### PR TITLE
Altering hyperpriors in bma to avoid numerical problems 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BRCindicators
 Type: Package
 Title: Creating multispecies biodiversity indicators
-Version: 1.3.6
-Date: 2020-04-10
+Version: 1.3.7
+Date: 2021-03-09
 Authors@R: c(person("Tom", "August", role = c("aut", "cre"), email = "tomaug@ceh.ac.uk"),
              person("Gary", "Powney", role = c("aut")),
              person("Charlie", "Outhwaite", role = c("aut")),
@@ -27,7 +27,7 @@ VignetteBuilder: knitr
 License: GPL-3
 URL: https://github.com/BiologicalRecordsCentre/BRCindicators
 BugReports: https://github.com/BiologicalRecordsCentre/BRCindicators/issues
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Encoding: UTF-8
 Suggests: 
     testthat,

--- a/R/bma_BUGS_models.R
+++ b/R/bma_BUGS_models.R
@@ -84,20 +84,20 @@ bma_model_Smooth <- function(incl.2deriv = FALSE,
     process_errors <- '
   # process errors
   tau.spi <- pow(sigma.spi,-2)
-  sigma.spi ~ dunif(0,30)'
+  sigma.spi ~ dunif(0.0001,30)'
     
     if(seFromData){
       obsErrors <- '
   # observation errors: one value per site-species
   for (s in 1:nsp){
    for (t in 1:nyears){
-    sigma.obs[s,t] ~ dunif(0, max_se) # for the missing values
+    sigma.obs[s,t] ~ dunif(0.0001, max_se) # for the missing values
   }}
     '
     } else {
       obsErrors <- '
   # observation error is constant
-  theta ~ dunif(0,10)'
+  theta ~ dunif(0.0001,10)'
     }
     
     return(paste(c(

--- a/R/butterflies_hs-data.R
+++ b/R/butterflies_hs-data.R
@@ -1,6 +1,7 @@
 #' @name butterflies_hs
 #' @title Data - UK Butterfly Monitoring Scheme - Habitat Specialists
 #' @description This dataset from the UK Butterfly Monitoring Scheme has national abundance indices for 26 species regarded as habitat specialists from 1976-2017.
+#' There are 1000 rows of data. Ten species have a complete time-series (42 years of data); 15 species join late (9 in the 1970s, 3 in the 1980s and 3 in the 1990s); the Swallowtail (Papilio machaon) spans the full range of years but has no data for 1978.
 #' @docType data
 #' @format 
 #' There are four columns of data:

--- a/R/butterflies_wc-data.R
+++ b/R/butterflies_wc-data.R
@@ -1,6 +1,7 @@
 #' @name butterflies_wc
 #' @title Data - UK Butterfly Monitoring Scheme - Wider Countryside Species
 #' @description This dataset from the UK Butterfly Monitoring Scheme has national abundance indices for 24 species regarded as wider countryside species from 1976-2017.
+#' There are 1005 lines of data, reflecting late entry into the time series for the Scotch Argus (Erebia aethops). Time-series for the other 23 species are complete.
 #' @docType data
 #' @usage data(butterflies_wc)
 #' @format 

--- a/R/dragonflies-data.R
+++ b/R/dragonflies-data.R
@@ -1,7 +1,7 @@
 #' @name dragonflies
 #' @title Data - British Dragonfly Society, UK
 #' @description This dataset contains annual occupancy estimates for 45 species of dragonflies and damselflies in the UK, 1970-2015.
-#' There are 2039 rows: 44 species have an estimate for every year, but the Small red-eyed damselfly has no estimates prior to 2001 (the first year in which it was recorded in UK).
+#' There are 2039 rows: 44 species have an estimate for every year, but the Small red-eyed damselfly (Erythromma viridulum) has no estimates prior to 2001 (the first year in which it was recorded in UK).
 #' The models are based on biological records data from the British Dragonfly Society.
 #' The data are derived from Bayesian occupancy detection models, described in Outhwaite et al (2019).
 #' @usage data(dragonflies)

--- a/man/bma.Rd
+++ b/man/bma.Rd
@@ -9,6 +9,7 @@ bma(
   plot = TRUE,
   model = "smooth",
   parallel = FALSE,
+  n.cores = parallel::detectCores() - 1,
   incl.model = TRUE,
   n.iter = 10000,
   n.thin = 5,
@@ -35,7 +36,9 @@ NB: Index values are assumed to be on the unbounded (logarithmic scale)}
 \item{model}{The type of model to be used. See details.}
 
 \item{parallel}{if \code{TRUE} the model chains will be run in parallel using one fewer cores than
-are available on the computer. NOTE: this will typically not work for parallel use on cluster PCs.}
+are available on the computer as default. NOTE: this will typically not work for parallel use on cluster PCs.}
+
+\item{n.cores}{if running the code in parallel this option specifies the number of cores to use.}
 
 \item{incl.model}{if \code{TRUE} the model is added as an attribute of the object returned}
 

--- a/man/butterflies_hs.Rd
+++ b/man/butterflies_hs.Rd
@@ -21,6 +21,7 @@ data(butterflies_hs)
 }
 \description{
 This dataset from the UK Butterfly Monitoring Scheme has national abundance indices for 26 species regarded as habitat specialists from 1976-2017.
+There are 1000 rows of data. Ten species have a complete time-series (42 years of data); 15 species join late (9 in the 1970s, 3 in the 1980s and 3 in the 1990s); the Swallowtail (Papilio machaon) spans the full range of years but has no data for 1978.
 }
 \examples{
 data(butterflies_hs)

--- a/man/butterflies_wc.Rd
+++ b/man/butterflies_wc.Rd
@@ -21,6 +21,7 @@ data(butterflies_wc)
 }
 \description{
 This dataset from the UK Butterfly Monitoring Scheme has national abundance indices for 24 species regarded as wider countryside species from 1976-2017.
+There are 1005 lines of data, reflecting late entry into the time series for the Scotch Argus (Erebia aethops). Time-series for the other 23 species are complete.
 }
 \examples{
 data(butterflies_wc)

--- a/man/dragonflies.Rd
+++ b/man/dragonflies.Rd
@@ -23,7 +23,7 @@ data(dragonflies)
 }
 \description{
 This dataset contains annual occupancy estimates for 45 species of dragonflies and damselflies in the UK, 1970-2015.
-There are 2039 rows: 44 species have an estimate for every year, but the Small red-eyed damselfly has no estimates prior to 2001 (the first year in which it was recorded in UK).
+There are 2039 rows: 44 species have an estimate for every year, but the Small red-eyed damselfly (Erythromma viridulum) has no estimates prior to 2001 (the first year in which it was recorded in UK).
 The models are based on biological records data from the British Dragonfly Society.
 The data are derived from Bayesian occupancy detection models, described in Outhwaite et al (2019).
 }


### PR DESCRIPTION
We found a problem whereby 0 was included in the prior range of `sd` parameters: when converted into precisions, this permits `Inf` to be included in the distribution of precision parameters, thus causing fail in JAGS. Fix is to add a small number to the hyperpriors.
A few other documentation issues fixed