### PR TITLE
Update to accommodate bma method for trend_assessment

### DIFF
--- a/BRCindicators.Rproj
+++ b/BRCindicators.Rproj
@@ -17,5 +17,5 @@ PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageBuildArgs: --no-build-vignettes
 PackageBuildBinaryArgs: --no-build-vignettes
-PackageCheckArgs: --no-build-vignettes --no-manual
+PackageCheckArgs: --no-build-vignettes
 PackageRoxygenize: rd,collate,namespace

--- a/BRCindicators.Rproj
+++ b/BRCindicators.Rproj
@@ -17,5 +17,5 @@ PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageBuildArgs: --no-build-vignettes
 PackageBuildBinaryArgs: --no-build-vignettes
-PackageCheckArgs: --no-build-vignettes
+PackageCheckArgs: --no-build-vignettes --no-manual
 PackageRoxygenize: rd,collate,namespace

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ VignetteBuilder: knitr
 License: GPL-3
 URL: https://github.com/BiologicalRecordsCentre/BRCindicators
 BugReports: https://github.com/BiologicalRecordsCentre/BRCindicators/issues
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Encoding: UTF-8
 Suggests: 
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BRCindicators
 Type: Package
 Title: Creating multispecies biodiversity indicators
-Version: 1.3.6
-Date: 2020-04-10
+Version: 1.3.7
+Date: 2021-05-24
 Authors@R: c(person("Tom", "August", role = c("aut", "cre"), email = "tomaug@ceh.ac.uk"),
              person("Gary", "Powney", role = c("aut")),
              person("Charlie", "Outhwaite", role = c("aut")),

--- a/R/misc_functions.r
+++ b/R/misc_functions.r
@@ -418,74 +418,126 @@ subset_years <- function(Occ, year_range = NULL){
   
 }
 
-species_assessment <- function(LogLambda,
+species_assessment <- function(dat,
+                               method = "lambda",
                                start_year = NULL,
                                end_year = NULL,
                                species_stat = 'mean',
-                               plot = FALSE){
-  # Sense check
+                               plot = FALSE) {
+  # Sense checks
+  if(!method %in% c("lambda", "bma")) stop("Method must be one of 'lambda' or 'bma'")
   if(!species_stat %in% c('mean', 'median')) stop("species_stat must be either 'mean' or 'median'")
   
-  # If we are subsetting
-  if(!is.null(start_year) | !is.null(end_year)){
-  
-    # If the assessment is only over a subset of the years do the subsetting first
-    if(is.null(dimnames(LogLambda)[[2]])){
-      
-      if(is.null(start_year)) start_year <- 1
-      if(is.null(end_year)) end_year <- dim(LogLambda)[2]
+  if(method == "lambda") {
     
-      if(end_year > dim(LogLambda)[2]){
+    # lambda method
+    LogLambda <- dat
+    
+    # If we are subsetting
+    if(!is.null(start_year) | !is.null(end_year)) {
+      
+      # If the assessment is only over a subset of the years do the subsetting first
+      if(is.null(dimnames(LogLambda)[[2]])) {
         
-        stop(paste('Years are un-named in your data and the specified end_year [',
-                   end_year,
-                   '] exceeds the number of years in the data [',
-                   dim(LogLambda)[2],
-                   ']', sep = ''))
+        if(is.null(start_year)) start_year <- 1
+        if(is.null(end_year)) end_year <- dim(LogLambda)[2]
+        
+        if(end_year > dim(LogLambda)[2]) {
+          
+          stop(paste('Years are un-named in your data and the specified end_year [',
+                     end_year,
+                     '] exceeds the number of years in the data [',
+                     dim(LogLambda)[2],
+                     ']', sep = ''))
+          
+        } else {
+          
+          LogLambda <- LogLambda[ , start_year:end_year, ]
+          
+        }
         
       } else {
         
-        LogLambda <- LogLambda[ , start_year:end_year, ]
+        if(is.null(start_year)) start_year <- as.character(min(as.numeric(dimnames(LogLambda)[[2]])))
+        if(is.null(end_year)) end_year <- as.character(max(as.numeric(dimnames(LogLambda)[[2]])))
+        
+        LogLambda <- LogLambda[ , as.character(start_year:end_year), ]
         
       }
       
-    } else {
-      
-      if(is.null(start_year)) start_year <- as.character(min(as.numeric(dimnames(LogLambda)[[2]])))
-      if(is.null(end_year)) end_year <- as.character(max(as.numeric(dimnames(LogLambda)[[2]])))
-      
-      LogLambda <- LogLambda[ , as.character(start_year:end_year), ]
-      
     }
+    
+    # Calculate the average change across this time period
+    if(species_stat == 'mean') spLogLamda <- rowMeans(apply(LogLambda, c(1,2), mean, na.rm = T), na.rm = T) # one value per species
+    if(species_stat == 'median') spLogLamda <- apply(apply(LogLambda, c(1,2), mean, na.rm = T), 1, FUN = median, na.rm = T)
+    
+    # Remove NAs
+    spLogLamda <- spLogLamda[!is.na(spLogLamda)]
+    
+    # this last value is simple, but conflates uncertainty with interannual variation
+    # of one value per species, convert to a percentage change per year
+    sp_pcpy <- 100 * (exp(spLogLamda) - 1)
+    
+    # Assign to cats
+    sp_cat <- cut(sp_pcpy, 
+                  breaks = c(-Inf,-2.73,-1.14,1.16,2.81,Inf),
+                  labels = c('strong decrease','decrease', 'no change', 'increase','strong increase'),
+                  ordered = T)
+    
+    # build DD
+    sp_change <- data.frame(percent_change_year = sp_pcpy, category = sp_cat)
+    
+    # Plot is desired
+    if(plot) plot_trend_stack(species_change = sp_change$category)
+    
+    return(sp_change)
+    
+  } else {
+    
+    # bma method
+    bma_df <- dat
+    
+    # mean growth rate between years per species
+    spgrowth <- attr(bma_df, "model")$mean$spgrowth
+    
+    yr_df <- data.frame(startyr = seq(min(bma_df$year), (max(bma_df$year) - 1), 1), 
+                        endyr = seq(min(bma_df$year) + 1, max(bma_df$year), 1),
+                        yr_col = seq(1, ncol(spgrowth), 1))
+    
+    if(is.null(start_year)) start_year <- 1 
+    # convert years from CE to numeric (e.g., 1970 to 1)
+    else start_year <- yr_df[yr_df$startyr == start_year,]$yr_col
+    
+    if(is.null(end_year)) end_year <- ncol(spgrowth)
+    # convert years from CE to numeric (e.g., 2016 to 46)
+    else end_year <- yr_df[yr_df$endyr == end_year,]$yr_col
+    
+    # subset to focal years
+    spgrowth_sub <- spgrowth[ , start_year:end_year]
+    
+    # average growth rate across years per species
+    if(species_stat == 'mean') spgrowth_av <- rowMeans(spgrowth_sub)
+    if(species_stat == 'median') spgrowth_av <- apply(spgrowth_sub, 1, median, na.rm = TRUE)
+    
+    # back-transform from log-scale
+    spg_pcpy <- 100*(exp(spgrowth_av)-1)
+    
+    # assign to categories
+    spg_cat <- cut(spg_pcpy, 
+                   breaks = c(-Inf,-2.73,-1.14,1.16,2.81,Inf),
+                   labels = c('Strong decrease','Decrease', 'No change', 'Increase','Strong increase'),
+                   ordered = TRUE)
+    
+    # build dataframe
+    sp_change <- data.frame(percent_change_year = spg_pcpy, category = spg_cat)
+    
+    # Plot is desired
+    if(plot) plot_trend_stack(species_change = sp_change$category)
+    
+    return(sp_change)
     
   }
   
-  # Calculate the average change across this time period
-  if(species_stat == 'mean') spLogLamda <- rowMeans(apply(LogLambda, c(1,2), mean, na.rm = T), na.rm = T) # one value per species
-  if(species_stat == 'median') spLogLamda <- apply(apply(LogLambda, c(1,2), mean, na.rm = T), 1, FUN = median, na.rm = T)
-
-  # Remove NAs
-  spLogLamda <- spLogLamda[!is.na(spLogLamda)]
-  
-  # this last value is simple, but conflates uncertainty with interannual variation
-  # of one value per species, convert to a percentage change per year
-  sp_pcpy <- 100 * (exp(spLogLamda) - 1)
-  
-  # Assign to cats
-  sp_cat <- cut(sp_pcpy, 
-                breaks = c(-Inf,-2.73,-1.14,1.16,2.81,Inf),
-                labels = c('strong decrease','decrease', 'no change', 'increase','strong increase'),
-                ordered = T)
-  
-  # build DD
-  sp_change <- data.frame(percent_change_year = sp_pcpy, category = sp_cat)
-  
-  # Plot is desired
-  if(plot) plot_trend_stack(species_change = sp_change$category)
-  
-  # Test change
-  
-  return(sp_change)
 }
 
 indicator_assessment <- function(summary_table,

--- a/R/trend_assessment.r
+++ b/R/trend_assessment.r
@@ -1,11 +1,12 @@
 #' Assess trends for indicator
 #' 
-#' @description  This assessment covers both the indicator and the constituant species.
+#' @description  This assessment covers both the indicator and the constituent species.
 #' An assessment is made of the indicator over the time period given, examining whether
-#' the initial indicator value falls within the credibal inverval of the final year.
+#' the initial indicator value falls within the credible interval of the final year.
 #' Over the same time period the change in each species is assessed and reported.
 #' 
-#' @param lambda_output An object returned by lambda_interpolation
+#' @param dat An object returned by lambda_interpolation or bma
+#' @param method Which indicator method was used to produce the data. One of "lambda" or "bma".
 #' @param start_year (Optional) a numeric value, defaults to the first year
 #' @param end_year (Optional) a numeric value, defaults to the last year
 #' @param species_stat (Optional) character, the statistic used to average across a species
@@ -45,22 +46,57 @@
 #' # Plot the trend stack
 #' trend_assessment(myIndicator)
 
-trend_assessment <- function(lambda_output,
-                             start_year = min(lambda_output$summary$year),
-                             end_year = max(lambda_output$summary$year),
+trend_assessment <- function(dat,
+                             method,
+                             start_year,
+                             end_year,
                              species_stat = 'mean'){
   
-  sp_assess <- species_assessment(LogLambda = lambda_output$LogLambda,
-                                  start_year = start_year + 1,
-                                  end_year = end_year,
-                                  species_stat = species_stat,
-                                  plot = TRUE)
+  # Sense check
+  if(!method %in% c("lambda", "bma")) stop("Method must be one of 'lambda' or 'bma'")
   
-  ind_assessment <- indicator_assessment(summary_table = lambda_output$summary,
-                                         start_year = start_year,
-                                         end_year = end_year)
-  
-  return(list(species_assessment = sp_assess,
-              indicator_asssessment = ind_assessment))
+  if(method == "lambda") {
+    
+    # lambda method
+    start_year <- min(dat$summary$year)
+    end_year <- max(dat$summary$year)
+    
+    sp_assess <- species_assessment(dat = dat$LogLambda,
+                                    method = method,
+                                    start_year = start_year + 1,
+                                    end_year = end_year,
+                                    species_stat = species_stat,
+                                    plot = FALSE)
+    
+    ind_assessment <- indicator_assessment(summary_table = dat$summary,
+                                           method = method,
+                                           start_year = start_year,
+                                           end_year = end_year)
+    
+    return(list(species_assessment = sp_assess,
+                indicator_asssessment = ind_assessment))
+    
+  } else {
+    
+    # bma method
+    start_year <- min(dat$year)
+    end_year <- max(dat$year)
+    
+    sp_assess <- species_assessment(dat = dat,
+                                    method = method,
+                                    start_year = start_year,
+                                    end_year = end_year,
+                                    species_stat = species_stat,
+                                    plot = FALSE)
+    
+    ind_assessment <- indicator_assessment(summary_table = dat,
+                                           method = method,
+                                           start_year = start_year,
+                                           end_year = end_year)
+    
+    return(list(species_assessment = sp_assess,
+                indicator_asssessment = ind_assessment))
+    
+  }
   
 }

--- a/R/trend_assessment.r
+++ b/R/trend_assessment.r
@@ -69,7 +69,6 @@ trend_assessment <- function(dat,
                                     plot = FALSE)
     
     ind_assessment <- indicator_assessment(summary_table = dat$summary,
-                                           method = method,
                                            start_year = start_year,
                                            end_year = end_year)
     
@@ -90,7 +89,6 @@ trend_assessment <- function(dat,
                                     plot = FALSE)
     
     ind_assessment <- indicator_assessment(summary_table = dat,
-                                           method = method,
                                            start_year = start_year,
                                            end_year = end_year)
     

--- a/R/trend_assessment.r
+++ b/R/trend_assessment.r
@@ -47,7 +47,7 @@
 #' trend_assessment(myIndicator)
 
 trend_assessment <- function(dat,
-                             method,
+                             method = "lambda",
                              start_year,
                              end_year,
                              species_stat = 'mean'){

--- a/R/trend_assessment.r
+++ b/R/trend_assessment.r
@@ -48,8 +48,8 @@
 
 trend_assessment <- function(dat,
                              method = "lambda",
-                             start_year,
-                             end_year,
+                             start_year = NULL,
+                             end_year = NULL,
                              species_stat = 'mean'){
   
   # Sense check
@@ -58,8 +58,8 @@ trend_assessment <- function(dat,
   if(method == "lambda") {
     
     # lambda method
-    start_year <- min(dat$summary$year)
-    end_year <- max(dat$summary$year)
+    if(is.null(start_year)) start_year <- min(dat$summary$year)
+    if(is.null(end_year)) end_year <- max(dat$summary$year)
     
     sp_assess <- species_assessment(dat = dat$LogLambda,
                                     method = method,
@@ -78,8 +78,8 @@ trend_assessment <- function(dat,
   } else {
     
     # bma method
-    start_year <- min(dat$year)
-    end_year <- max(dat$year)
+    if(is.null(start_year)) start_year <- min(dat$year)
+    if(is.null(end_year)) end_year <- max(dat$year)
     
     sp_assess <- species_assessment(dat = dat,
                                     method = method,

--- a/man/bma.Rd
+++ b/man/bma.Rd
@@ -9,6 +9,7 @@ bma(
   plot = TRUE,
   model = "smooth",
   parallel = FALSE,
+  n.cores = parallel::detectCores() - 1,
   incl.model = TRUE,
   n.iter = 10000,
   n.thin = 5,
@@ -35,7 +36,9 @@ NB: Index values are assumed to be on the unbounded (logarithmic scale)}
 \item{model}{The type of model to be used. See details.}
 
 \item{parallel}{if \code{TRUE} the model chains will be run in parallel using one fewer cores than
-are available on the computer. NOTE: this will typically not work for parallel use on cluster PCs.}
+are available on the computer as default. NOTE: this will typically not work for parallel use on cluster PCs.}
+
+\item{n.cores}{if running the code in parallel this option specifies the number of cores to use.}
 
 \item{incl.model}{if \code{TRUE} the model is added as an attribute of the object returned}
 

--- a/man/trend_assessment.Rd
+++ b/man/trend_assessment.Rd
@@ -5,14 +5,17 @@
 \title{Assess trends for indicator}
 \usage{
 trend_assessment(
-  lambda_output,
-  start_year = min(lambda_output$summary$year),
-  end_year = max(lambda_output$summary$year),
+  dat,
+  method = "lambda",
+  start_year = NULL,
+  end_year = NULL,
   species_stat = "mean"
 )
 }
 \arguments{
-\item{lambda_output}{An object returned by lambda_interpolation}
+\item{dat}{An object returned by lambda_interpolation or bma}
+
+\item{method}{Which indicator method was used to produce the data. One of "lambda" or "bma".}
 
 \item{start_year}{(Optional) a numeric value, defaults to the first year}
 
@@ -27,9 +30,9 @@ Returns a list of two elements, a summary of the species and indicator
 assessments. A plot of the species assessment is returned to the device.
 }
 \description{
-This assessment covers both the indicator and the constituant species.
+This assessment covers both the indicator and the constituent species.
 An assessment is made of the indicator over the time period given, examining whether
-the initial indicator value falls within the credibal inverval of the final year.
+the initial indicator value falls within the credible interval of the final year.
 Over the same time period the change in each species is assessed and reported.
 }
 \examples{


### PR DESCRIPTION
I've updated `species_assessment` and `trend_assessment` so they can be applied to either the lambda method or bma method (via the `method` argument).

I had to add `--no-manual` to the Check Package options, else it produces a build error that is unfixable on my OS as far as I can tell: "Error in texi2dvi(file = file, pdf = TRUE, clean = clean, quiet = quiet, : pdflatex is not available"
